### PR TITLE
Copy English sentences into Farsi directory

### DIFF
--- a/sentences/fa/HassGetState/name_only.yaml
+++ b/sentences/fa/HassGetState/name_only.yaml
@@ -1,0 +1,13 @@
+---
+# HassGetState - name_only
+# example: what is the value of sensor 1
+# slots: {name}
+
+language: "en"
+
+data:
+  - sentences:
+      - "what is [the [value of [the]]] {name}"
+    name_domains:
+      - "sensor"
+    response: "default"

--- a/sentences/fa/HassGetState/name_state.yaml
+++ b/sentences/fa/HassGetState/name_state.yaml
@@ -1,0 +1,15 @@
+---
+# HassGetState - name_state
+# example: is the sliding door open
+# slots:
+# - {name}
+# - {state}
+
+language: "en"
+
+data:
+  - sentences:
+      - "is [the] {name} {cover_states:state}"
+    name_domains:
+      - "cover"
+    response: "one_yesno"

--- a/sentences/fa/HassLightSet/name_brightness.yaml
+++ b/sentences/fa/HassLightSet/name_brightness.yaml
@@ -1,0 +1,18 @@
+---
+# HassLightSet - name_brightness
+# example: set the overhead light brightness to 50%
+# slots:
+# - {name}
+# - {brightness}
+# name domains: light
+
+language: "en"
+
+data:
+  - sentences:
+      - "[<numeric_value_set>] [<the>] {name} brightness [to] {brightness}[<percent>]"
+      - "[<numeric_value_set>] [the] brightness [of] [<the>] {name} [to] {brightness}[<percent>]"
+      - "[<numeric_value_set>] [<the>] {name} [to] {brightness}[<percent>] [brightness]"
+    name_domains:
+      - "light"
+    response: "brightness"

--- a/sentences/fa/HassLightSet/name_color.yaml
+++ b/sentences/fa/HassLightSet/name_color.yaml
@@ -1,0 +1,17 @@
+---
+# HassLightSet - name_color
+# example: set the overhead light to red
+# slots:
+# - {name}
+# - {color}
+# name domains: light
+
+language: "en"
+
+data:
+  - sentences:
+      - "[<set>] [<the>] {name} [color] [to] {color}"
+      - "[<set>] [the] color of [<the>] {name} to {color}"
+    name_domains:
+      - "light"
+    response: "color"

--- a/sentences/fa/HassMediaSearchAndPlay/area_only.yaml
+++ b/sentences/fa/HassMediaSearchAndPlay/area_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaSearchAndPlay - area_only
+# example: play Pink Floyd in the Kitchen
+# slots:
+# - {area}
+# - {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query} in [the] {area}"
+    response: "default"

--- a/sentences/fa/HassMediaSearchAndPlay/default.yaml
+++ b/sentences/fa/HassMediaSearchAndPlay/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaSearchAndPlay - default
+# example: play Pink Floyd
+# slots: {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query}"
+    response: "default"

--- a/sentences/fa/HassMediaSearchAndPlay/name_area.yaml
+++ b/sentences/fa/HassMediaSearchAndPlay/name_area.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaSearchAndPlay - name_area
+# example: play Pink Floyd on the Sonos Speakers in the Kitchen
+# slots:
+# - {area}
+# - {name}
+# - {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query} on [the] {name} in [the] {area}"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/fa/HassMediaSearchAndPlay/name_only.yaml
+++ b/sentences/fa/HassMediaSearchAndPlay/name_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassMediaSearchAndPlay - name_only
+# example: play Pink Floyd on Sonos Speakers
+# slots:
+# - {name}
+# - {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query} on [the] {name}"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/fa/HassNevermind/default.yaml
+++ b/sentences/fa/HassNevermind/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassNevermind - default
+# English example: nevermind
+
+language: "en"
+data:
+  - sentences:
+      - "nevermind"
+      - "never mind"
+    response: "default"

--- a/sentences/fa/HassTimerStatus/default.yaml
+++ b/sentences/fa/HassTimerStatus/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassTimerStatus - default
+# example: how much time is left on my timer
+
+language: "en"
+
+data:
+  - sentences:
+      - "timer status"
+    response: "default"

--- a/sentences/fa/HassTurnOff/area_domain.yaml
+++ b/sentences/fa/HassTurnOff/area_domain.yaml
@@ -1,0 +1,13 @@
+---
+# HassTurnOff - area_domain
+# example: turn off the lights in the kitchen
+# slots: {area}
+
+language: "en"
+
+data:
+  - sentences:
+      - "turn off [all|the|all of the] {area} lights"
+      - "turn off [all|the|all of the] lights in [the] {area}"
+    inferred_domain: "light"
+    response: "lights_area"

--- a/sentences/fa/HassTurnOff/domain_only.yaml
+++ b/sentences/fa/HassTurnOff/domain_only.yaml
@@ -1,0 +1,22 @@
+---
+# HassTurnOff - domain_only
+# example: turn off the lights in here
+# context_area: true
+
+language: "en"
+
+data:
+  - sentences:
+      # Explicit <here> optional all
+      - "<turn> [(<all>|<the>)] <light> ((off|out);<here>)"
+      - "<turn> (off|out) [(<all>|<the>)] <light> <here>"
+      - "deactivate [(<all>|<the>)] <light> <here>"
+      - "[<all>] [<the>] <light> (off|out) <here>"
+
+      # Implicit <here> no all
+      - "<turn> [<the>] <light> ((off|out);[<here>])"
+      - "<turn> (off|out) [<the>] <light> [<here>]"
+      - "deactivate [<the>] <light> [<here>]"
+      - "<light> (off|out) [<here>]"
+    inferred_domain: "light"
+    response: "lights_area"

--- a/sentences/fa/HassTurnOff/name_only.yaml
+++ b/sentences/fa/HassTurnOff/name_only.yaml
@@ -1,0 +1,27 @@
+---
+# HassTurnOff - name_only
+# example: turn off the overhead light
+# slots: {name}
+
+language: "en"
+
+data:
+  - sentences:
+      - "<turn> off [<the>] {name}"
+      - "[<turn>] [<the>] {name} [to] off"
+      - "deactivate [<the>] {name}"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+
+  # covers
+  - sentences:
+      - "close [<the>] {name}"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "cover"

--- a/sentences/fa/HassTurnOn/area_domain.yaml
+++ b/sentences/fa/HassTurnOn/area_domain.yaml
@@ -1,0 +1,21 @@
+---
+# HassTurnOn - area_domain
+# example: turn on the lights in the kitchen
+# slots: {area}
+
+language: "en"
+
+data:
+  - sentences:
+      - "(light up|illuminate) [<the>] {area}"
+      - "[<the>] {area} <light> on"
+      - "<light> on [in] [<the>] {area}"
+      - "<turn> on [<all>] [<the>] {area} <light>"
+      - "<turn> on [(<all>|<the>)] <light> <in> [<the>] {area}"
+      - "<turn> [<all>] [<the>] {area} <light> on"
+      - "<turn> [(<all>|<the>)] <light> <in> [<the>] {area} on"
+      - "<turn> [(<all>|<the>)] <light> on <in> [<the>] {area}"
+      - "activate [<all>] [<the>] {area} <light>"
+      - "activate [(<all>|<the>)] <light> <in> [<the>] {area}"
+    inferred_domain: "light"
+    response: "lights_area"

--- a/sentences/fa/HassTurnOn/domain_only.yaml
+++ b/sentences/fa/HassTurnOn/domain_only.yaml
@@ -1,0 +1,24 @@
+---
+# HassTurnOn - domain_only
+# English example: turn on the lights in here
+# context_area: true
+
+language: "en"
+
+data:
+  - sentences:
+      # Explicit <here> optional all
+      - "<turn> [(<all>|<the>)] <light> (on;<here>)"
+      - "<turn> on [(<all>|<the>)] <light> <here>"
+      - "activate [(<all>|<the>)] <light> <here>"
+      - "[(<all>|<the>)] <light> on <here>"
+
+      # Implicit <here> no all
+      - "<turn> [<the>] <light> (on;[<here>])"
+      - "<turn> on [<the>] <light> [<here>]"
+      - "activate [<the>] <light> [<here>]"
+      - "<light> on [<here>]"
+      - "light (it|<here>) up"
+      - "light up [<here>]"
+    inferred_domain: "light"
+    response: "lights_area"

--- a/sentences/fa/HassTurnOn/name_only.yaml
+++ b/sentences/fa/HassTurnOn/name_only.yaml
@@ -1,0 +1,26 @@
+---
+# HassTurnOn - name_only
+# example: turn on the overhead light
+# slots: {name}
+
+language: "en"
+data:
+  - sentences:
+      - "<turn> on [<the>] {name}"
+      - "[<the>] {name} [to] on"
+      - "[<the>] {name}"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+
+  # covers
+  - sentences:
+      - "<open> [<the>] {name}"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "cover"

--- a/sentences/fa/_common.yaml
+++ b/sentences/fa/_common.yaml
@@ -1,37 +1,59 @@
-language: fa
+language: "en"
 responses:
   errors:
-    no_intent: "ببخشید نتونستم بفهمم"
-    no_area: "وجود ندارد {{ area }} هیچ منطقه ای به نام"
-    no_domain_in_area: "نیست {{ domain }} دارای {{ area }}"
-    no_device_class_in_area: "نیست {{ device_class }} دارای {{ area }}"
-    no_entity: "وجود ندارد {{ entity }} هیچ دستگاه یا موجودی به نام"
-    handle_error: "هنگام اجرای هدف یک خطای غیر منتظره بوجود آمد "
+    # General errors
+    no_intent: "Sorry, I couldn't understand that"
+    handle_error: "An unexpected error occurred"
+
+    # Errors for when user is not logged in
+    no_area: "Sorry, I am not aware of any area called {{ area }}"
+    no_floor: "Sorry, I am not aware of any floor called {{ floor }}"
+    no_domain: "Sorry, I am not aware of any {{ domain }}"
+    no_domain_in_area: "Sorry, I am not aware of any {{ domain }} in the {{ area }} area"
+    no_domain_in_floor: "Sorry, I am not aware of any {{ domain }} on the {{ floor }} floor"
+    no_device_class: "Sorry, I am not aware of any {{ device_class }}"
+    no_device_class_in_area: "Sorry, I am not aware of any {{ device_class }} in the {{ area }} area"
+    no_device_class_in_floor: "Sorry, I am not aware of any {{ device_class }} in the {{ floor }} floor"
+    no_entity: "Sorry, I am not aware of any device called {{ entity }}"
+    no_entity_in_area: "Sorry, I am not aware of any device called {{ entity }} in the {{ area }} area"
+    no_entity_in_floor: "Sorry, I am not aware of any device called {{ entity }} in the {{ floor }} floor"
+    entity_wrong_state: "Sorry, no device is {{ state | lower }}"
+    feature_not_supported: "Sorry, no device supports the required features"
+
+    # Errors for when user is logged in and we can give more information
+    no_entity_exposed: "Sorry, {{ entity }} is not exposed"
+    no_entity_in_area_exposed: "Sorry, {{ entity }} in the {{ area }} area is not exposed"
+    no_entity_in_floor_exposed: "Sorry, {{ entity }} in the {{ floor }} floor is not exposed"
+    no_domain_exposed: "Sorry, no {{ domain }} is exposed"
+    no_domain_in_area_exposed: "Sorry, no {{ domain }} in the {{ area }} area is exposed"
+    no_domain_in_floor_exposed: "Sorry, no {{ domain }} in the {{ floor }} floor is exposed"
+    no_device_class_exposed: "Sorry, no {{ device_class }} is exposed"
+    no_device_class_in_area_exposed: "Sorry, no {{ device_class }} in the {{ area }} area is exposed"
+    no_device_class_in_floor_exposed: "Sorry, no {{ device_class }} in the {{ floor }} floor is exposed"
+
+    # Used when multiple (exposed) devices have the same name
+    duplicate_entities: "Sorry, there are multiple devices called {{ entity }}"
+    duplicate_entities_in_area: "Sorry, there are multiple devices called {{ entity }} in the {{ area }} area"
+    duplicate_entities_in_floor: "Sorry, there are multiple devices called {{ entity }} in the {{ floor }} floor"
+
+    # Errors for timers
+    timer_not_found: "Sorry, I couldn't find that timer"
+    multiple_timers_matched: "Sorry, I am unable to target multiple timers"
+    no_timer_support: "Sorry, timers are not supported on this device"
 lists:
   color:
     values:
-      - in: "سفید"
-        out: "white"
-      - in: "(سیاه|مشکی)"
-        out: "black"
-      - in: "قرمز"
-        out: "red"
-      - in: "نارنجی"
-        out: "orange"
-      - in: "زرد"
-        out: "yellow"
-      - in: "سبز"
-        out: "green"
-      - in: "آبی"
-        out: "blue"
-      - in: "بنفش"
-        out: "purple"
-      - in: "صورتی"
-        out: "pink"
-      - in: "قهوه ای"
-        out: "brown"
-      - in: "(طوسی|خاکستری)"
-        out: "gray"
+      - "white"
+      - "black"
+      - "red"
+      - "orange"
+      - "yellow"
+      - "green"
+      - "blue"
+      - "purple"
+      - "brown"
+      - "pink"
+      - "turquoise"
   brightness:
     range:
       type: "percentage"
@@ -42,5 +64,405 @@ lists:
       type: "temperature"
       from: 0
       to: 100
-expansion_rules: {}
-skip_words: []
+      fractions: "halves"
+  brightness_level:
+    values:
+      - in: (max|maximum|highest)
+        out: 100
+      - in: (min|minimum|lowest)
+        out: 1
+  on_off_states:
+    values:
+      - in: "on"
+        out: "on"
+      - in: "off"
+        out: "off"
+  on_off_domains:
+    values:
+      - in: light[s]
+        out: light
+      - in: fan[s]
+        out: fan
+      - in: switch[es]
+        out: switch
+  cover_states:
+    values:
+      - in: "open"
+        out: "open"
+      - in: "(closed|shut)"
+        out: "closed"
+      - in: "opening"
+        out: "opening"
+      - in: "(closing|shutting)"
+        out: "closing"
+  cover_classes:
+    values:
+      - in: awning[s]
+        out: awning
+      - in: blind[s]
+        out: blind
+      - in: curtain[s]
+        out: curtain
+      - in: door[s]
+        out: door
+      - in: garage door[s]
+        out: garage
+      - in: gate[s]
+        out: gate
+      - in: shade[s]
+        out: shade
+      - in: shutter[s]
+        out: shutter
+      - in: window[s]
+        out: window
+  lock_states:
+    values:
+      - in: "[securely] locked"
+        out: "locked"
+      - in: "unlocked"
+        out: "unlocked"
+
+  # binary_sensor
+  bs_battery_states:
+    values:
+      - in: "low"
+        out: "on"
+      - in: "(normal|charged)"
+        out: "off"
+
+  bs_battery_charging_states:
+    values:
+      - in: "charging"
+        out: "on"
+      - in: "not charging"
+        out: "off"
+
+  bs_carbon_monoxide_states:
+    values:
+      - in: "(detected|triggered|on)"
+        out: "on"
+      - in: "clear"
+        out: "off"
+
+  bs_cold_states:
+    values:
+      - in: "cold"
+        out: "on"
+      - in: "normal"
+        out: "off"
+
+  bs_connectivity_states:
+    values:
+      - in: "connected"
+        out: "on"
+      - in: "disconnected"
+        out: "off"
+
+  bs_door_states:
+    values:
+      - in: "open"
+        out: "on"
+      - in: "(closed|shut)"
+        out: "off"
+
+  bs_garage_door_states:
+    values:
+      - in: "open"
+        out: "on"
+      - in: "(closed|shut)"
+        out: "off"
+
+  bs_gas_states:
+    values:
+      - in: "(detected|triggered|on)"
+        out: "on"
+      - in: "clear"
+        out: "off"
+
+  bs_heat_states:
+    values:
+      - in: "hot"
+        out: "on"
+      - in: "normal"
+        out: "off"
+
+  bs_light_states:
+    values:
+      - in: "detected"
+        out: "on"
+      - in: "no light"
+        out: "off"
+
+  bs_lock_states:
+    values:
+      - in: "unlocked"
+        out: "on"
+      - in: "locked"
+        out: "off"
+
+  bs_moisture_states:
+    values:
+      - in: "wet"
+        out: "on"
+      - in: "dry"
+        out: "off"
+
+  bs_motion_states:
+    values:
+      - in: "(detected|triggered|on)"
+        out: "on"
+      - in: "clear"
+        out: "off"
+
+  bs_occupancy_states:
+    values:
+      - in: "(detected|triggered|on)"
+        out: "on"
+      - in: "clear"
+        out: "off"
+
+  bs_opening_states:
+    values:
+      - in: "open"
+        out: "on"
+      - in: "(closed|shut)"
+        out: "off"
+
+  bs_plug_states:
+    values:
+      - in: "plugged in"
+        out: "on"
+      - in: "unplugged"
+        out: "off"
+
+  bs_power_states:
+    values:
+      - in: "(powered [on]|power detected)"
+        out: "on"
+      - in: "(not powered|powered off)"
+        out: "off"
+
+  bs_presence_states:
+    values:
+      - in: "(home|present)"
+        out: "on"
+      - in: "(away|not (home|present)|gone)"
+        out: "off"
+
+  bs_problem_states:
+    values:
+      - in: "detected"
+        out: "on"
+      - in: "ok"
+        out: "off"
+
+  bs_running_states:
+    values:
+      - in: "running"
+        out: "on"
+      - in: "not running"
+        out: "off"
+
+  bs_safety_states:
+    values:
+      - in: "unsafe"
+        out: "on"
+      - in: "safe"
+        out: "off"
+
+  bs_smoke_states:
+    values:
+      - in: "(detected|triggered|on)"
+        out: "on"
+      - in: "clear"
+        out: "off"
+
+  bs_sound_states:
+    values:
+      - in: "(detected|triggered|on)"
+        out: "on"
+      - in: "clear"
+        out: "off"
+
+  bs_tamper_states:
+    values:
+      - in: "(detected|tampered with)"
+        out: "on"
+      - in: "clear"
+        out: "off"
+
+  bs_update_states:
+    values:
+      - in: "update available"
+        out: "on"
+      - in: "(up to date|up-to-date)"
+        out: "off"
+
+  bs_vibration_states:
+    values:
+      - in: "(detected|vibrating)"
+        out: "on"
+      - in: "(clear|not vibrating)"
+        out: "off"
+
+  bs_window_states:
+    values:
+      - in: "open"
+        out: "on"
+      - in: "(closed|shut)"
+        out: "off"
+
+  shopping_list_item:
+    wildcard: true
+
+  todo_list_item:
+    wildcard: true
+
+  zone:
+    wildcard: true
+
+  position:
+    range:
+      type: "percentage"
+      from: 0
+      to: 100
+
+  volume:
+    range:
+      type: "percentage"
+      from: 0
+      to: 100
+
+  timer_seconds:
+    range:
+      from: 1
+      to: 100
+  timer_minutes:
+    range:
+      from: 1
+      to: 100
+  timer_hours:
+    range:
+      from: 1
+      to: 100
+  timer_half:
+    values:
+      - in: "half"
+        out: 30
+      - in: "1/2"
+        out: 30
+  timer_name:
+    wildcard: true
+  timer_command:
+    wildcard: true
+
+  message:
+    wildcard: true
+
+  search_query:
+    wildcard: true
+
+  media_class:
+    values:
+      - in: "artist"
+        out: "artist"
+      - in: "album"
+        out: "album"
+      - in: "(track|song)"
+        out: "track"
+      - in: "playlist"
+        out: "playlist"
+      - in: "podcast"
+        out: "podcast"
+      - in: "movie"
+        out: "movie"
+      - in: "[tv] show"
+        out: "tv_show"
+
+  fan_speed:
+    range:
+      type: "percentage"
+      from: 0
+      to: 100
+
+  volume_step_up:
+    range:
+      type: percentage
+      from: 0
+      to: 100
+
+  volume_step_down:
+    range:
+      type: percentage
+      from: 0
+      to: 100
+      multiplier: -1
+
+expansion_rules:
+  the: "(the|my|our)"
+  name: "[<the>] {name}"
+  area: "[<the>] {area}"
+  floor: "[<the>] {floor} [floor]"
+  area_floor: "(<area>|<floor>)"
+  in_area_floor: "[<in>] <area_floor>"
+  what_is: "(what's|whats|what is|tell me)"
+  how_is: "(how is|how's|hows)"
+  lockable: "[<the>] (lock|door|window|gate|garage door|shutter)[s]"
+  where_is: "(where's|wheres|where is)"
+  which: "(which|what) [of <the>]"
+  is: "(is|are) [(there|<the>)]"
+  are: "<is>"
+  any: "(any|some) [of <the>]"
+  are_any: "[<are>] <any>"
+  how_many: "how many [of <the>]"
+  brightness: "{brightness}[([ ]%)| percent]"
+  light: "(light|lights|lighting|lamp|lamps)"
+  turn: "(turn|switch|change|bring)"
+  temp: "(temp|temperature)"
+  temperature: "{temperature}[([ ]°)|( degree[s])]"
+  open: "(open|raise|lift) [up]"
+  close: "(close|shut|lower) [(up|down)]"
+  set: "(set|make|change|turn)"
+  numeric_value_set: "(set|change|turn [(up|down)]|increase|decrease|make)"
+  in: "(in|on|at|of|across|around|throughout)"
+  position: "{position}[([ ]%)| percent]"
+  volume: "{volume:volume_level}[([ ]%)| percent]"
+  currently: "(currently|presently|right now|at the moment)"
+  state: "[(present|current)] (state|status)"
+  clean: (vacuum|clean)
+
+  # Context awareness expansion rules
+  all: "(all [[of] <the>]|every [single]|each [and every])"
+  are_all: "[<are>] <all>"
+  home: "(home|house|apartment|flat)"
+  everywhere: "(everywhere|all over|[<in>] <the> [(entire|whole)] <home>|[<in>] <all> (room|area|floor)[s])"
+  here: "([in] here|[in] (this|<the>) (room|area|space))"
+
+  # Questions
+  what_is_the_class_of_name: "(<what_is> the <class> (of|in|from|(indicated|measured) by) <name> [in <area>]|<what_is> <name>['s] <class> [in <area>]|<what_is> <area> <name>['s] <class>)"
+
+  # Timers
+  timer_set: "(start|set|create)"
+  timer_cancel: "(cancel|stop)"
+  timer_duration_seconds: "{timer_seconds:seconds} second[s]"
+  timer_duration_minutes: "({timer_minutes:minutes} minute[s] [[and] {timer_seconds:seconds} second[s]])|({timer_minutes:minutes} and [a] {timer_half:seconds} minute[s])|({timer_half:seconds} a minute[s])"
+  timer_duration_hours: "({timer_hours:hours} hour[s] [[and] {timer_minutes:minutes} minute[s]] [[and] {timer_seconds:seconds} second[s]])|({timer_hours:hours} and [a] {timer_half:minutes} hour[s])|({timer_half:minutes} an hour[s])"
+  timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
+
+  timer_start_seconds: "{timer_seconds:start_seconds} second[s]"
+  timer_start_minutes: "{timer_minutes:start_minutes} minute[s] [[and] {timer_seconds:start_seconds} second[s]]"
+  timer_start_hours: "{timer_hours:start_hours} hour[s] [[and] {timer_minutes:start_minutes} minute[s]] [[and] {timer_seconds:start_seconds} second[s]]"
+  timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
+
+  # Fans
+  fan_speed: "{fan_speed:percentage}[%| percent]"
+
+skip_words:
+  - "please"
+  - "can you"
+  - "could you"
+  - "would you"
+  - "for me"
+  - "i'd like"
+  - "i'd like to"
+  - "i want"

--- a/sentences/fa/assist_satellite_HassBroadcast.yaml
+++ b/sentences/fa/assist_satellite_HassBroadcast.yaml
@@ -1,0 +1,6 @@
+language: "en"
+intents:
+  HassBroadcast:
+    data:
+      - sentences:
+          - "(broadcast|announce) [everywhere] [that] {message}"

--- a/sentences/fa/binary_sensor_HassGetState.yaml
+++ b/sentences/fa/binary_sensor_HassGetState.yaml
@@ -1,0 +1,895 @@
+language: en
+intents:
+  HassGetState:
+    data:
+      # https://www.home-assistant.io/integrations/binary_sensor/
+      # Battery
+      - sentences:
+          - "(is|are) <name> [battery] {bs_battery_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: battery
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "(is|are) any batter(y|ies) {bs_battery_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "are all [the] batter(y|ies) {bs_battery_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "(which|what) batter(y|ies) (is|are) {bs_battery_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "how many batter(y|ies) (is|are) {bs_battery_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      # Battery charging
+      - sentences:
+          - "(is|are) <name> [battery] {bs_battery_charging_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: battery_charging
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "(is|are) any batter(y|ies) {bs_battery_charging_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "are all [the] batter(y|ies) {bs_battery_charging_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "(which|what) batter(y|ies) (is|are) {bs_battery_charging_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "how many batter(y|ies) (is|are) {bs_battery_charging_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      # Carbon monoxide
+      - sentences:
+          - "(is|are) <name> {bs_carbon_monoxide_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: carbon_monoxide
+        slots:
+          domain: binary_sensor
+          device_class: carbon_monoxide
+
+      - sentences:
+          - "(is|are) any carbon monoxide sensor[s] {bs_carbon_monoxide_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: carbon_monoxide
+
+      - sentences:
+          - "is there [any] carbon monoxide in <area>"
+          - "is [there] [any] carbon monoxide detected in <area>"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: carbon_monoxide
+          state: "on"
+
+      - sentences:
+          - "are all [the] carbon monoxide sensors {bs_carbon_monoxide_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: carbon_monoxide
+
+      - sentences:
+          - "(which|what) carbon monoxide sensor[s] (is|are) {bs_carbon_monoxide_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: carbon_monoxide
+
+      - sentences:
+          - "how many carbon monoxide sensors (is|are) {bs_carbon_monoxide_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: carbon_monoxide
+
+      # Cold
+      - sentences:
+          - "(is|are) <name> {bs_cold_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: cold
+        slots:
+          domain: binary_sensor
+          device_class: cold
+
+      - sentences:
+          - "(is|are) any[ ](thing|sensor)[s] cold [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: cold
+          state: "on"
+
+      - sentences:
+          - "(which|what) (thing|sensor)[s] (is|are) cold [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: cold
+          state: "on"
+
+      - sentences:
+          - "how many (thing|sensor)[s] (is|are) cold [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: cold
+          state: "on"
+
+      # Connectivity
+      - sentences:
+          - "(is|are) <name> {bs_connectivity_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: connectivity
+        slots:
+          domain: binary_sensor
+          device_class: connectivity
+
+      - sentences:
+          - "(is|are) any device[s] {bs_connectivity_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: connectivity
+
+      - sentences:
+          - "are all [the] device[s] {bs_connectivity_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: connectivity
+
+      - sentences:
+          - "(which|what) device[s] (is|are) {bs_connectivity_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: connectivity
+
+      - sentences:
+          - "how many device[s] (is|are) {bs_connectivity_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: connectivity
+
+      # Door
+      - sentences:
+          - "(is|are) <name> {bs_door_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: door
+        slots:
+          domain: binary_sensor
+          device_class: door
+
+      # Garage door
+      - sentences:
+          - "(is|are) <name> {bs_garage_door_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: garage_door
+        slots:
+          domain: binary_sensor
+          device_class: garage_door
+
+      # Gas
+      - sentences:
+          - "(is|are) <name> {bs_gas_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: gas
+        slots:
+          domain: binary_sensor
+          device_class: gas
+
+      - sentences:
+          - "(is|are) any gas sensor[s] {bs_gas_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: gas
+
+      - sentences:
+          - "is there [any] gas in <area>"
+          - "is [there] [any] gas detected in <area>"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: gas
+          state: "on"
+
+      - sentences:
+          - "are all [the] gas sensor[s] {bs_gas_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: gas
+
+      - sentences:
+          - "(which|what) gas sensor[s] (is|are) {bs_gas_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: gas
+
+      - sentences:
+          - "how many gas sensor[s] (is|are) {bs_gas_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: gas
+
+      # Heat
+      - sentences:
+          - "(is|are) <name> {bs_heat_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: heat
+        slots:
+          domain: binary_sensor
+          device_class: heat
+
+      - sentences:
+          - "(is|are) any[ ](thing|sensor)[s] hot [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: heat
+          state: "on"
+
+      - sentences:
+          - "(which|what) (thing|sensor)[s] (is|are) hot [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: heat
+          state: "on"
+
+      - sentences:
+          - "how many (thing|sensor)[s] (is|are) hot [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: heat
+          state: "on"
+
+      # Light
+      - sentences:
+          - "(is|are) <name> {bs_light_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: light
+        slots:
+          domain: binary_sensor
+          device_class: light
+
+      - sentences:
+          - "(is|are) any light[s] {bs_light_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: light
+
+      - sentences:
+          - "are all [the] light[s] {bs_light_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: light
+
+      - sentences:
+          - "(which|what) light[s] (is|are) {bs_light_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: light
+
+      - sentences:
+          - "how many light[s] (is|are) {bs_light_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: light
+
+      # Lock
+      - sentences:
+          - "(is|are) <name> {bs_lock_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: lock
+        slots:
+          domain: binary_sensor
+          device_class: lock
+
+      # Moisture
+      - sentences:
+          - "(is|are) <name> {bs_moisture_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: moisture
+        slots:
+          domain: binary_sensor
+          device_class: moisture
+
+      - sentences:
+          - "(is|are) any water sensor[s] {bs_moisture_states:state} [in <area>]"
+          - "is (it|the (floor|[(water [leak[ing]]|leak[ing]|flood[ing])] sensor)) {bs_moisture_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: moisture
+
+      - sentences:
+          - "is [there] a[ny] (flood|leak) [detected] [in <area>]"
+          - "is <area> flooded"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: moisture
+          state: "on"
+
+      - sentences:
+          - "are all [the] water sensor[s] {bs_moisture_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: moisture
+
+      - sentences:
+          - "(which|what) water sensor[s] (is|are) {bs_moisture_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: moisture
+
+      - sentences:
+          - "how many water sensor[s] (is|are) {bs_moisture_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: moisture
+
+      # Motion
+      - sentences:
+          - "(is|are) <name> {bs_motion_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: motion
+        slots:
+          domain: binary_sensor
+          device_class: motion
+
+      - sentences:
+          - "(is|are) (any|the) motion sensor[s] {bs_motion_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: motion
+
+      - sentences:
+          - "is [there] [any] motion detected [in <area>]"
+          - "is there [any] motion [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: motion
+          state: "on"
+
+      - sentences:
+          - "are all [the] motion sensor[s] {bs_motion_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: motion
+
+      - sentences:
+          - "(which|what) motion sensor[s] (is|are) {bs_motion_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: motion
+
+      - sentences:
+          - "how many motion sensor[s] (is|are) {bs_motion_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: motion
+
+      # Occupancy
+      - sentences:
+          - "(is|are) <name> {bs_occupancy_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: occupancy
+        slots:
+          domain: binary_sensor
+          device_class: occupancy
+
+      - sentences:
+          - "(is|are) any occupancy sensor[s] {bs_occupancy_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: occupancy
+
+      - sentences:
+          - "is [there] any occupancy detected [in <area>]"
+          - "is <area> occupied"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: occupancy
+          state: "on"
+
+      - sentences:
+          - "are all [the] occupancy sensor[s] {bs_occupancy_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: occupancy
+
+      - sentences:
+          - "(which|what) occupancy sensor[s] (is|are) {bs_occupancy_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: occupancy
+
+      - sentences:
+          - "how many occupancy sensor[s] (is|are) {bs_occupancy_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: occupancy
+
+      # Opening
+      - sentences:
+          - "(is|are) <name> {bs_opening_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: opening
+        slots:
+          domain: binary_sensor
+          device_class: opening
+
+      - sentences:
+          - "(is|are) any opening[s] {bs_opening_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: opening
+
+      - sentences:
+          - "are all [the] opening[s] {bs_opening_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: opening
+
+      - sentences:
+          - "(which|what) opening[s] (is|are) {bs_opening_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: opening
+
+      - sentences:
+          - "how many opening[s] (is|are) {bs_opening_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: opening
+
+      # Plug
+      - sentences:
+          - "(is|are) <name> {bs_plug_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: plug
+        slots:
+          domain: binary_sensor
+          device_class: plug
+
+      - sentences:
+          - "(is|are) any (thing[s]|device[s]) {bs_plug_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: plug
+
+      - sentences:
+          - "are all [the] (thing[s]|device[s]) {bs_plug_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: plug
+
+      - sentences:
+          - "(which|what) (thing[s]|device[s]) (is|are) {bs_plug_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: plug
+
+      - sentences:
+          - "how many (thing[s]|device[s]) (is|are) {bs_plug_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: plug
+
+      # Power
+      - sentences:
+          - "(is|are) <name> {bs_power_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: power
+        slots:
+          domain: binary_sensor
+          device_class: power
+
+      - sentences:
+          - "(is|are) any (thing[s]|device[s]) {bs_power_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: power
+
+      - sentences:
+          - "are all [the] (thing[s]|device[s]) {bs_power_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: power
+
+      - sentences:
+          - "(which|what) (thing[s]|device[s]) (is|are) {bs_power_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: power
+
+      - sentences:
+          - "how many (thing[s]|device[s]) (is|are) {bs_power_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: power
+
+      # Presence
+      - sentences:
+          - "(is|are) <name> {bs_presence_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: presence
+        slots:
+          domain: binary_sensor
+          device_class: presence
+
+      - sentences:
+          - "(is|are) any (thing[s]|device[s]) {bs_presence_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: presence
+
+      - sentences:
+          - "are all [the] (thing[s]|device[s]) {bs_presence_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: presence
+
+      - sentences:
+          - "(which|what) (thing[s]|device[s]) (is|are) {bs_presence_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: presence
+
+      - sentences:
+          - "how many (thing[s]|device[s]) (is|are) {bs_presence_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: presence
+
+      # Problem
+      - sentences:
+          - "are there [any] problems with <name> [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: problem
+        slots:
+          domain: binary_sensor
+          device_class: problem
+          state: "on"
+
+      # Running
+      - sentences:
+          - "(is|are) <name> {bs_running_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: running
+        slots:
+          domain: binary_sensor
+          device_class: running
+
+      - sentences:
+          - "(is|are) any (thing[s]|device[s]) {bs_running_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: running
+
+      - sentences:
+          - "are all [the] (thing[s]|device[s]) {bs_running_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: running
+
+      - sentences:
+          - "(which|what) (thing[s]|device[s]) (is|are) {bs_running_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: running
+
+      - sentences:
+          - "how many (thing[s]|device[s]) (is|are) {bs_running_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: running
+
+      # Safety
+      - sentences:
+          - "(is|are) <name> {bs_safety_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: safety
+        slots:
+          domain: binary_sensor
+          device_class: safety
+
+      # Smoke
+      - sentences:
+          - "(is|are) <name> {bs_smoke_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: smoke
+        slots:
+          domain: binary_sensor
+          device_class: smoke
+
+      - sentences:
+          - "(is|are) any smoke sensor[s] {bs_smoke_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: smoke
+
+      - sentences:
+          - "is [there] [any] smoke in <area>"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: smoke
+          state: "on"
+
+      - sentences:
+          - "are all [the] smoke sensor[s] {bs_smoke_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: smoke
+
+      - sentences:
+          - "(which|what) smoke sensor[s] (is|are) {bs_smoke_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: smoke
+
+      - sentences:
+          - "how many smoke sensor[s] (is|are) {bs_smoke_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: smoke
+
+      # Sound
+      - sentences:
+          - "(is|are) <name> {bs_sound_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: sound
+        slots:
+          domain: binary_sensor
+          device_class: sound
+
+      - sentences:
+          - "(is|are) any (noise|sound) sensor[s] {bs_sound_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: sound
+
+      - sentences:
+          - "is [there] [any] noise in <area>"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: sound
+          state: "on"
+
+      - sentences:
+          - "are all [the] (noise|sound) sensor[s] {bs_sound_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: sound
+
+      - sentences:
+          - "(which|what) (noise|sound) sensor[s] (is|are) {bs_sound_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: sound
+
+      - sentences:
+          - "how many (noise|sound) sensor[s] (is|are) {bs_sound_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: sound
+
+      # Tamper
+      - sentences:
+          - "(is|are) <name> {bs_tamper_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: tamper
+        slots:
+          domain: binary_sensor
+          device_class: tamper
+
+      # Update
+      - sentences:
+          - "(is|are) <name> {bs_update_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: update
+        slots:
+          domain: binary_sensor
+          device_class: update
+
+      - sentences:
+          - "are [there] any [(firmware|software)] updates [available] [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: update
+          state: "on"
+
+      - sentences:
+          - "(which|what) [(firmware|software)] updates are (there|available) [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: update
+          state: "on"
+
+      - sentences:
+          - "how many [(firmware|software)] updates are (there|available) [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: update
+          state: "on"
+
+      # Vibration
+      - sentences:
+          - "(is|are) <name> {bs_vibration_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: vibration
+        slots:
+          domain: binary_sensor
+          device_class: vibration
+
+      - sentences:
+          - "is anything vibrating [in <area>]"
+        response: any
+        requires_context:
+          domain: binary_sensor
+          device_class: vibration
+        slots:
+          domain: binary_sensor
+          device_class: vibration
+          state: "on"
+
+      # Window
+      - sentences:
+          - "(is|are) <name> {bs_window_states:state} [in <area>]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: window
+        slots:
+          domain: binary_sensor
+          device_class: window

--- a/sentences/fa/climate_HassClimateGetTemperature.yaml
+++ b/sentences/fa/climate_HassClimateGetTemperature.yaml
@@ -1,5 +1,19 @@
-language: fa
+language: "en"
 intents:
   HassClimateGetTemperature:
     data:
-      - sentences: []
+      # Get temperature of a climate in the same area as a satellite device
+      - sentences:
+          - "(<what_is>|<how_is>) [the] [current] <temp> [<here>]"
+          - "how (hot|cold|warm|cool) is it [<here>]"
+        requires_context:
+          area:
+            slot: true
+
+      # Get temperature of a climate in an area or with a name
+      - sentences:
+          - "(<what_is>|<how_is>) [the] [current] <temp> [of] <name>"
+          - "(<what_is>|<how_is>) [the] [current] <temp> <in> <area>"
+          - "(<what_is>|<how_is>) <area> [current] <temp>"
+          - "(<what_is>|<how_is>) <name> [current] <temp>"
+          - "how (hot|cold|warm|cool) is (<name>|[it <in>] <area>)"

--- a/sentences/fa/climate_HassClimateSetTemperature.yaml
+++ b/sentences/fa/climate_HassClimateSetTemperature.yaml
@@ -1,5 +1,24 @@
-language: fa
+language: "en"
 intents:
   HassClimateSetTemperature:
     data:
-      - sentences: []
+      # Current area or floor
+      - sentences:
+          - "(<numeric_value_set>|adjust) [the] <temp> to <temperature>"
+
+      # By area name
+      - sentences:
+          - "(<numeric_value_set>|adjust) [the] <temp> in <area> to <temperature>"
+          - "(<numeric_value_set>|adjust) <area> <temp> to <temperature>"
+
+      # By floor name
+      - sentences:
+          - "(<numeric_value_set>|adjust) [the] <temp> (of|on) <floor> to <temperature>"
+          - "(<numeric_value_set>|adjust) <floor> <temp> to <temperature>"
+
+      # By climate entity name
+      - sentences:
+          - "(<numeric_value_set>|adjust) [the] <temp> of <name> to <temperature>"
+          - "(<numeric_value_set>|adjust) <name> [<temp>] to <temperature>"
+        requires_context:
+          domain: "climate"

--- a/sentences/fa/cover_HassGetState.yaml
+++ b/sentences/fa/cover_HassGetState.yaml
@@ -1,4 +1,47 @@
-language: fa
+language: en
 intents:
   HassGetState:
-    data: []
+    data:
+      - sentences:
+          - "<is> <name> {cover_states:state} [<in_area_floor>]"
+        response: one_yesno
+        requires_context:
+          domain: cover
+        slots:
+          domain: cover
+
+      - sentences:
+          - "<what_is> [the] <state> of <name> [<in_area_floor>]"
+        response: one
+        requires_context:
+          domain: cover
+        slots:
+          domain: cover
+
+      - sentences:
+          - "<are_any> {cover_classes:device_class} {cover_states:state} [<in_area_floor>]"
+          - "<are_any> <area_floor> {cover_classes:device_class} {cover_states:state}"
+        response: any
+        slots:
+          domain: cover
+
+      - sentences:
+          - "<are_all> {cover_classes:device_class} {cover_states:state} [<in_area_floor>]"
+          - "<are_all> <area_floor> {cover_classes:device_class} {cover_states:state}"
+        response: all
+        slots:
+          domain: cover
+
+      - sentences:
+          - "<which> {cover_classes:device_class} <is> {cover_states:state} [<in_area_floor>]"
+          - "<which> <area_floor> {cover_classes:device_class} <is> {cover_states:state}"
+        response: which
+        slots:
+          domain: cover
+
+      - sentences:
+          - "<how_many> {cover_classes:device_class} <is> {cover_states:state} [<in_area_floor>]"
+          - "<how_many> <area_floor> {cover_classes:device_class} <is> {cover_states:state}"
+        response: how_many
+        slots:
+          domain: cover

--- a/sentences/fa/cover_HassSetPosition.yaml
+++ b/sentences/fa/cover_HassSetPosition.yaml
@@ -1,0 +1,28 @@
+language: en
+intents:
+  HassSetPosition:
+    data:
+      - sentences:
+          - "(<numeric_value_set>|<open>|<close>) <name> [position] to <position>"
+        requires_context:
+          domain: cover
+        slots:
+          domain: cover
+
+      - sentences:
+          - "(<numeric_value_set>|<open>|<close>) [the] {cover_classes:device_class} [position] (to <position>;in <area>)"
+          - "(<numeric_value_set>|<open>|<close>) <area> {cover_classes:device_class} [position] to <position>"
+        slots:
+          domain: cover
+
+      - sentences:
+          - "(<numeric_value_set>) [the] {cover_classes:device_class} [position] [<in_here>] to <position>"
+          - "(<open>|<close>) [the] {cover_classes:device_class} [<in_here>] to <position>"
+        expansion_rules:
+          in_here: "[in] here"
+        slots:
+          domain: cover
+        response: cover_device_class
+        requires_context:
+          area:
+            slot: true

--- a/sentences/fa/cover_HassTurnOff.yaml
+++ b/sentences/fa/cover_HassTurnOff.yaml
@@ -1,4 +1,34 @@
-language: fa
+language: en
 intents:
   HassTurnOff:
-    data: []
+    data:
+      - sentences:
+          - "<close> <name> [in <area>]"
+        requires_context:
+          domain: cover
+        response: cover
+
+      - sentences:
+          - "<close> [the] garage door"
+        slots:
+          domain: cover
+          device_class: garage
+        response: cover_device_class
+
+      - sentences:
+          - "<close> [the] {cover_classes:device_class} in <area>"
+          - "<close> <area> {cover_classes:device_class}"
+        slots:
+          domain: cover
+        response: cover_device_class
+
+      - sentences:
+          - "<close> [the] {cover_classes:device_class} [<in_here>]"
+        expansion_rules:
+          in_here: "[in] here"
+        slots:
+          domain: cover
+        response: cover_device_class
+        requires_context:
+          area:
+            slot: true

--- a/sentences/fa/cover_HassTurnOn.yaml
+++ b/sentences/fa/cover_HassTurnOn.yaml
@@ -1,4 +1,34 @@
-language: fa
+language: en
 intents:
   HassTurnOn:
-    data: []
+    data:
+      - sentences:
+          - "<open> <name> [in <area>]"
+        requires_context:
+          domain: cover
+        response: cover
+
+      - sentences:
+          - "<open> [the] garage door"
+        slots:
+          domain: cover
+          device_class: garage
+        response: cover_device_class
+
+      - sentences:
+          - "<open> [the] {cover_classes:device_class} in <area>"
+          - "<open> <area> {cover_classes:device_class}"
+        slots:
+          domain: cover
+        response: cover_device_class
+
+      - sentences:
+          - "<open> [the] {cover_classes:device_class} [<in_here>]"
+        expansion_rules:
+          in_here: "[in] here"
+        slots:
+          domain: cover
+        response: cover_device_class
+        requires_context:
+          area:
+            slot: true

--- a/sentences/fa/fan_HassFanSetSpeed.yaml
+++ b/sentences/fa/fan_HassFanSetSpeed.yaml
@@ -1,0 +1,25 @@
+---
+language: "en"
+intents:
+  HassFanSetSpeed:
+    data:
+      # Current area
+      - sentences:
+          - "[<set>] fan[s] [speed] [<here>] [to] <fan_speed>"
+          - "[<set>] [the] speed [of [the]] fan[s] [<here>] [to] <fan_speed>"
+        requires_context:
+          area:
+            slot: true
+
+      # Fan by name
+      - sentences:
+          - "[<set>] <name> [speed] [to] <fan_speed>"
+          - "[<set>] [the] speed [of] <name> [to] <fan_speed>"
+        requires_context:
+          domain: "fan"
+
+      # Area/floor by name
+      - sentences:
+          - "[<set>] <area_floor> fan[s] [speed] [to] <fan_speed>"
+          - "[<set>] [the] speed [of] <area_floor> fan[s] [to] <fan_speed>"
+          - "[<set>] [the] speed [of] fan[s] (in|on) <area_floor> [to] <fan_speed>"

--- a/sentences/fa/fan_HassTurnOff.yaml
+++ b/sentences/fa/fan_HassTurnOff.yaml
@@ -1,8 +1,36 @@
-language: fa
+language: "en"
 intents:
   HassTurnOff:
     data:
-      - sentences: []
+      - sentences:
+          - "<turn> off [all] [the] fan[s] in <area>"
+          - "<turn> off <area> fan[s]"
+          - "[<turn>] [all] <area> fan[s] off"
+          - "[<turn>] [all] [the] fan[s] [in] <area> off"
+          - "deactivate [all] [the] fan[s] [in] <area>"
+          - "deactivate [all] <area> [the] fan[s]"
+        slots:
+          domain: "fan"
+          name: "all"
+        response: fans_area
+
+      - sentences:
+          - "[<turn>] (all [the] fan[s] off|[the] fan[s] off everywhere)"
+          - "deactivate (all [the] fan[s]|[the] fan[s] everywhere)"
+        response: "light_all"
+        slots:
+          domain: "fan"
+          name: "all"
+
+      - sentences:
+          - "<turn> off [all] [the] fan[s] [<in_here>]"
+          - "<turn> [all] [the] fan[s] (off;<in_here>)"
+          - "<turn> [all] [the] fan[s] off"
+        response: "fans_area"
+        expansion_rules:
+          in_here: "[in] here"
         slots:
           domain: fan
-          name: all
+        requires_context:
+          area:
+            slot: true

--- a/sentences/fa/fan_HassTurnOn.yaml
+++ b/sentences/fa/fan_HassTurnOn.yaml
@@ -1,8 +1,27 @@
-language: fa
+language: "en"
 intents:
   HassTurnOn:
     data:
-      - sentences: []
+      - sentences:
+          - "<turn> on [all] [the] fan[s] in <area>"
+          - "<turn> on <area> fan[s]"
+          - "[<turn>] [all] <area> fan[s] on"
+          - "activate [all] <area> fan[s]"
+          - "activate [all] fan[s] [in] <area>"
+        slots:
+          domain: "fan"
+          name: "all"
+        response: fans_area
+
+      - sentences:
+          - "<turn> on [all] [the] fan[s] [<in_here>]"
+          - "<turn> [all] [the] fan[s] (on;<in_here>)"
+          - "<turn> [all] [the] fan[s] on"
+        response: "fans_area"
+        expansion_rules:
+          in_here: "[in] here"
         slots:
           domain: fan
-          name: all
+        requires_context:
+          area:
+            slot: true

--- a/sentences/fa/homeassistant_HassCancelAllTimers.yaml
+++ b/sentences/fa/homeassistant_HassCancelAllTimers.yaml
@@ -1,0 +1,11 @@
+---
+language: "en"
+intents:
+  HassCancelAllTimers:
+    data:
+      - sentences:
+          - "<timer_cancel> all [[of ](the|my)] timers"
+      - sentences:
+          - "<timer_cancel> all [[of ](the|my)] {area} timers"
+          - "<timer_cancel> all [[of ](the|my)] timers in <area>"
+        response: area

--- a/sentences/fa/homeassistant_HassCancelTimer.yaml
+++ b/sentences/fa/homeassistant_HassCancelTimer.yaml
@@ -1,0 +1,13 @@
+---
+language: "en"
+intents:
+  HassCancelTimer:
+    data:
+      - sentences:
+          - "<timer_cancel> [the|my] timer"
+          - "<timer_cancel> [the|my] <timer_start> timer"
+          - "<timer_cancel> [the|my] timer for <timer_start>"
+          - "<timer_cancel> [the|my] {area} timer"
+          - "<timer_cancel> [the|my] timer in <area>"
+          - "<timer_cancel> [the|my] {timer_name:name} timer"
+          - "<timer_cancel> [the|my] timer for {timer_name:name}"

--- a/sentences/fa/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/fa/homeassistant_HassDecreaseTimer.yaml
@@ -1,0 +1,32 @@
+---
+language: "en"
+intents:
+  HassDecreaseTimer:
+    data:
+      # Remove...
+      - sentences:
+          - "remove <timer_duration> from [the|my] timer"
+          - "remove <timer_duration> from [the|my] <timer_start> timer"
+          - "remove <timer_duration> from [the|my] timer for <timer_start>"
+          - "remove <timer_duration> from [the|my] {area} timer"
+          - "remove <timer_duration> from [the|my] timer in <area>"
+          - "remove <timer_duration> from [the|my] {timer_name:name} timer"
+          - "remove <timer_duration> from [the|my] timer (named|called|for) {timer_name:name}"
+      # Take...
+      - sentences:
+          - "take <timer_duration> [from|off] [the|my] timer"
+          - "take <timer_duration> [from|off] [the|my] <timer_start> timer"
+          - "take <timer_duration> [from|off] [the|my] timer for <timer_start>"
+          - "take <timer_duration> [from|off] [the|my] {area} timer"
+          - "take <timer_duration> [from|off] [the|my] timer in <area>"
+          - "take <timer_duration> [from|off] [the|my] {timer_name:name} timer"
+          - "take <timer_duration> [from|off] [the|my] timer (named|called|for) {timer_name:name}"
+      # Decrease...
+      - sentences:
+          - "decrease [the|my] timer by <timer_duration>"
+          - "decrease [the|my] <timer_start> timer by <timer_duration>"
+          - "decrease [the|my] timer for <timer_start> by <timer_duration>"
+          - "decrease [the|my] {area} timer by <timer_duration>"
+          - "decrease [the|my] timer in <area> by <timer_duration>"
+          - "decrease [the|my] {timer_name:name} timer by <timer_duration>"
+          - "decrease [the|my] timer (named|called|for) {timer_name:name} by <timer_duration>"

--- a/sentences/fa/homeassistant_HassGetCurrentDate.yaml
+++ b/sentences/fa/homeassistant_HassGetCurrentDate.yaml
@@ -1,0 +1,7 @@
+language: en
+intents:
+  HassGetCurrentDate:
+    data:
+      - sentences:
+          - "<what_is> (todays|today's|the current) date"
+          - "<what_is> the date [today]"

--- a/sentences/fa/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/fa/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,7 @@
+language: en
+intents:
+  HassGetCurrentTime:
+    data:
+      - sentences:
+          - "<what_is> the [current] time"
+          - "what time is it [[right] now]"

--- a/sentences/fa/homeassistant_HassGetState.yaml
+++ b/sentences/fa/homeassistant_HassGetState.yaml
@@ -1,4 +1,36 @@
-language: fa
+language: en
 intents:
   HassGetState:
-    data: []
+    data:
+      - sentences:
+          - (do you know|tell me|<what_is>) [the [current] (state|value) of] <name> [<in_area_floor>]
+        response: one
+        excludes_context:
+          domain:
+            - scene
+            - script
+      - sentences:
+          - is [the] [state of] <name> {on_off_states:state} [<in_area_floor>]
+        response: one_yesno
+        excludes_context:
+          domain:
+            - cover
+            - binary_sensor
+
+      - sentences:
+          - (is|are) [there] any {on_off_domains:domain} {on_off_states:state} [<in_area_floor>]
+          - (do you know|tell me) if there are any {on_off_domains:domain} {on_off_states:state} [<in_area_floor>]
+        response: any
+
+      - sentences:
+          - are all [the] {on_off_domains:domain} [(switched|turned|set [to])] {on_off_states:state} [<in_area_floor>]
+          - are all [the] {on_off_domains:domain} <in_area_floor> [(switched|turned|set [to])] {on_off_states:state}
+        response: all
+
+      - sentences:
+          - "[do you know] (which|what) {on_off_domains:domain} (is|are) {on_off_states:state} [<in_area_floor>]"
+        response: which
+
+      - sentences:
+          - "[tell me] how many {on_off_domains:domain} (is|are) {on_off_states:state} [<in_area_floor>]"
+        response: how_many

--- a/sentences/fa/homeassistant_HassIncreaseTimer.yaml
+++ b/sentences/fa/homeassistant_HassIncreaseTimer.yaml
@@ -1,0 +1,21 @@
+---
+language: "en"
+intents:
+  HassIncreaseTimer:
+    data:
+      - sentences:
+          - "add <timer_duration> to [the|my] timer"
+          - "add <timer_duration> to [the|my] <timer_start> timer"
+          - "add <timer_duration> to [the|my] timer for <timer_start>"
+          - "add <timer_duration> to [the|my] {area} timer"
+          - "add <timer_duration> to [the|my] timer in <area>"
+          - "add <timer_duration> to [the|my] {timer_name:name} timer"
+          - "add <timer_duration> to [the|my] timer (named|called|for) {timer_name:name}"
+      - sentences:
+          - "increase [the|my] timer by <timer_duration>"
+          - "increase [the|my] <timer_start> timer by <timer_duration>"
+          - "increase [the|my] timer for <timer_start> by <timer_duration>"
+          - "increase [the|my] {area} timer by <timer_duration>"
+          - "increase [the|my] timer in <area> by <timer_duration>"
+          - "increase [the|my] {timer_name:name} timer by <timer_duration>"
+          - "increase [the|my] timer (named|called|for) {timer_name:name} by <timer_duration>"

--- a/sentences/fa/homeassistant_HassNevermind.yaml
+++ b/sentences/fa/homeassistant_HassNevermind.yaml
@@ -1,7 +1,7 @@
-language: fa
-
+language: en
 intents:
   HassNevermind:
     data:
       - sentences:
-          - "مهم نیست"
+          - "nevermind"
+          - "never mind"

--- a/sentences/fa/homeassistant_HassPauseTimer.yaml
+++ b/sentences/fa/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,13 @@
+---
+language: "en"
+intents:
+  HassPauseTimer:
+    data:
+      - sentences:
+          - "pause [the|my] timer"
+          - "pause [the|my] <timer_start> timer"
+          - "pause [the|my] timer for <timer_start>"
+          - "pause [the|my] {area} timer"
+          - "pause [the|my] timer in <area>"
+          - "pause [the|my] {timer_name:name} timer"
+          - "pause [the|my] timer (named|called|for) {timer_name:name}"

--- a/sentences/fa/homeassistant_HassRespond.yaml
+++ b/sentences/fa/homeassistant_HassRespond.yaml
@@ -1,0 +1,23 @@
+language: "en"
+intents:
+  HassRespond:
+    data:
+      - sentences:
+          - "(hello|hi) [home assistant]"
+        response: hello
+
+      - sentences:
+          - "are you always (listening|recording)"
+        response: listening
+
+      - sentences:
+          - "where does (my|the) data go [to]"
+        response: data
+
+      - sentences:
+          - "what can I (say|ask)"
+        response: commands
+
+      - sentences:
+          - "who (made|created) you"
+        response: creator

--- a/sentences/fa/homeassistant_HassStartTimer.yaml
+++ b/sentences/fa/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,19 @@
+---
+language: "en"
+intents:
+  HassStartTimer:
+    data:
+      - sentences:
+          - "timer for <timer_duration>"
+          - "timer for <timer_duration> (named|called) {timer_name:name}"
+          - "<timer_duration> timer"
+          - "<timer_duration> timer for {timer_name:name}"
+          - "<timer_set> [a|the|my] timer for <timer_duration>"
+          - "<timer_set> [a|an|the|my] <timer_duration> timer (named|called|for) {timer_name:name}"
+          - "<timer_set> [a|an|the|my] <timer_duration> timer"
+          - "<timer_set> [a|the|my] timer (named|called) {timer_name:name} for <timer_duration>"
+          - "<timer_set> [a|the|my] timer for <timer_duration> (named|called) {timer_name:name}"
+      - sentences:
+          - "{timer_command:conversation_command} in <timer_duration>"
+          - "in <timer_duration> {timer_command:conversation_command}"
+        response: command

--- a/sentences/fa/homeassistant_HassTimerStatus.yaml
+++ b/sentences/fa/homeassistant_HassTimerStatus.yaml
@@ -1,0 +1,52 @@
+---
+language: "en"
+intents:
+  HassTimerStatus:
+    data:
+      # Timer status
+      - sentences:
+          - "<timer_start> timer status"
+          - "timer[s] status"
+          - "{area} timer status"
+        required_keywords:
+          - "timer"
+          - "timers"
+          - "status"
+      # How much...
+      - sentences:
+          - "[how much] time [is] left on [the|my] timer[s]"
+          - "[how much] time [is] left on [the|my] <timer_start> timer"
+          - "[how much] time [is] left on [the|my] {area} timer"
+          - "[how much] time [is] left on [the|my] timer[s] in <area>"
+        required_keywords:
+          - "timer"
+          - "timers"
+          - "left"
+      # How long...
+      - sentences:
+          - "how long [is] left on [the|my] timer[s]"
+          - "how long [is] left on [the|my] <timer_start> timer"
+          - "how long [is] left on [the|my] {area} timer"
+          - "how long [is] left on [the|my] timer[s] in <area>"
+        required_keywords:
+          - "timer"
+          - "timers"
+          - "left"
+      # Status of...
+      - sentences:
+          - "status of [the|my] timer[s]"
+          - "status of [the|my] <timer_start> timer"
+          - "status of [the|my] {area} timer[s]"
+          - "status of [the|my] timer[s] in <area>"
+        required_keywords:
+          - "timer"
+          - "timers"
+      # Named timers
+      - sentences:
+          - "{timer_name:name} timer status"
+          - "[how much] time [is] left on [the|my] {timer_name:name} timer"
+          - "status of [the|my] {timer_name:name} timer[s]"
+          - "how long [is] left on [the|my] {timer_name:name} timer"
+        required_keywords:
+          - "timer"
+          - "timers"

--- a/sentences/fa/homeassistant_HassTurnOff.yaml
+++ b/sentences/fa/homeassistant_HassTurnOff.yaml
@@ -1,6 +1,16 @@
-language: fa
+language: en
 intents:
   HassTurnOff:
     data:
       - sentences:
-          - "{name} (را | رو) خاموش کن"
+          - "<turn> off (<area> <name>|<name> [in <area>])"
+          - "[<turn>] (<area> <name>|<name> [in <area>]) [to] off"
+          - "deactivate (<area> <name>|<name> [in <area>])"
+        excludes_context:
+          domain:
+            - binary_sensor
+            - cover
+            - lock
+            - scene
+            - script
+            - sensor

--- a/sentences/fa/homeassistant_HassTurnOn.yaml
+++ b/sentences/fa/homeassistant_HassTurnOn.yaml
@@ -1,6 +1,17 @@
-language: fa
+language: en
 intents:
   HassTurnOn:
     data:
       - sentences:
-          - "{name} (را | رو) روشن کن"
+          - "<turn> on (<area> <name>|<name> [in <area>])"
+          - "[<turn>] (<area> <name>|<name> [in <area>]) [to] on"
+          - "activate (<area> <name>|<name> [in <area>])"
+        excludes_context:
+          domain:
+            - binary_sensor
+            - cover
+            - lock
+            - scene
+            - script
+            - sensor
+            - valve

--- a/sentences/fa/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/fa/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,13 @@
+---
+language: "en"
+intents:
+  HassUnpauseTimer:
+    data:
+      - sentences:
+          - "(resume|continue) [the|my] timer"
+          - "(resume|continue) [the|my] <timer_start> timer"
+          - "(resume|continue) [the|my] timer for <timer_start>"
+          - "(resume|continue) [the|my] {area} timer"
+          - "(resume|continue) [the|my] timer in <area>"
+          - "(resume|continue) [the|my] timer (named|called|for) {timer_name:name}"
+          - "(resume|continue) [the|my] {timer_name:name} timer"

--- a/sentences/fa/light_HassLightSet.yaml
+++ b/sentences/fa/light_HassLightSet.yaml
@@ -1,5 +1,98 @@
-language: fa
+language: "en"
 intents:
   HassLightSet:
     data:
-      - sentences: []
+      # brightness
+      - sentences:
+          - "[<numeric_value_set>] <name> brightness [to] <brightness>"
+          - "[<numeric_value_set>] [the] brightness [of] <name> [to] <brightness>"
+          - "[<numeric_value_set>] <name> [to] <brightness> [brightness]"
+        response: "brightness"
+        requires_context:
+          domain: light
+
+      - sentences:
+          - "<numeric_value_set> <name> to <brightness>"
+        requires_context:
+          domain: "light"
+        response: "brightness"
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness in <area> to <brightness>"
+          - "[<numeric_value_set>] [the] brightness of <area> to <brightness>"
+          - "[<numeric_value_set>] <area> brightness [to] <brightness>"
+          - "[<numeric_value_set>] <area> [to] <brightness> brightness"
+          - "[<numeric_value_set>] <area> [to] <brightness>"
+          - "[<numeric_value_set>] [(<all>|<the>)] <light> [<in>] <area> to <brightness> [brightness]"
+        response: "brightness"
+
+      - sentences:
+          - "<numeric_value_set> <area> to <brightness>"
+        response: "brightness"
+
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness to <brightness>"
+          - "[<numeric_value_set>] [the] brightness (<in_here>;to <brightness>)"
+        expansion_rules:
+          in_here: "[in] here"
+        response: "brightness"
+        requires_context:
+          area:
+            slot: true
+
+      # Max/Min brightness
+      - sentences:
+          - "[<numeric_value_set>] <name> brightness to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] [the] brightness of <name> to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] <name> [to] [the] {brightness_level:brightness} brightness"
+        requires_context:
+          domain: light
+        response: "brightness"
+
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness in <area> to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] [the] brightness of <area> to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] <area> brightness to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] <area> [to] [the] {brightness_level:brightness} brightness"
+        response: "brightness"
+
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] [the] brightness (<in_here>;to [the] {brightness_level:brightness})"
+        expansion_rules:
+          in_here: "[in] here"
+        response: "brightness"
+        requires_context:
+          area:
+            slot: true
+
+      # Floor support for brightness
+      - sentences:
+          - "[<numeric_value_set>] <floor> brightness [to] <brightness>"
+        response: "brightness"
+
+      # color
+      - sentences:
+          - "[<set>] <name> [color] [to] {color}"
+          - "[<set>] [[the] color of] <name> to {color}"
+        requires_context:
+          domain: light
+        response: "color"
+      - sentences:
+          - "[<set>] [[the] color of] (<area> | [<all>] lights in <area> | [all] <area> lights) [to] {color}"
+          - "[<set>] (<area> | [all] lights in <area> | [all] <area> lights) [color] [to] {color}"
+        response: "color"
+
+      - sentences:
+          - "[<set>] [[the] color of] [(<all>|<the>)] <light> [to] {color}"
+          - "[<set>] [[the] color of] [(<all>|<the>)] <light> (<in_here>;[to] {color})"
+        expansion_rules:
+          in_here: "[in] here"
+        response: "color"
+        requires_context:
+          area:
+            slot: true
+
+      # Floor support for color
+      - sentences:
+          - "[<set>] <floor> [color] [to] {color}"
+        response: "color"

--- a/sentences/fa/light_HassTurnOff.yaml
+++ b/sentences/fa/light_HassTurnOff.yaml
@@ -1,8 +1,81 @@
-language: fa
+language: "en"
 intents:
   HassTurnOff:
     data:
-      - sentences: []
+      # Turn off a specific light
+      - sentences:
+          - "<turn> off <area_floor> <name> <light>"
+          - "<turn> off <name> <light> [<in_area_floor>]"
+          - "[<turn>] <area_floor> <name> <light> [to] off"
+          - "[<turn>] <name> <light> [<in_area_floor>] [to] off"
+          - "deactivate <area_floor> <name> <light>"
+          - "deactivate <name> <light> [<in_area_floor>]"
+        requires_context:
+          domain: "light"
+
+      # Turn off all lights in an area
+      - sentences:
+          - "<area> <light> (off|out)"
+          - "<light> (off|out) [<in>] <area>"
+          - "<turn> (off|out) [<all>] <area> <light>"
+          - "<turn> (off|out) [(<all>|<the>)] <light> <in> <area>"
+          - "[<turn>] [<all>] <area> <light> (off|out)"
+          - "[<turn>] [(<all>|<the>)] <light> <in> <area> (off|out)"
+          - "[<turn>] [(<all>|<the>)] <light> (off|out) <in> <area>"
+          - "deactivate [<all>] <area> <light>"
+          - "deactivate [(<all>|<the>)] <light> <in> <area>"
         slots:
-          domain: light
-          name: all
+          domain: "light"
+        response: "lights_area"
+
+      # Turn off all lights on a floor
+      - sentences:
+          - "<floor> <light> (off|out)"
+          - "<light> (off|out) [<in>] <floor>"
+          - "<turn> (off|out) [<all>] <floor> <light>"
+          - "<turn> (off|out) [(<all>|<the>)] <light> [<in>] <floor>"
+          - "[<turn>] [<all>] <floor> <light> (off|out)"
+          - "[<turn>] [(<all>|<the>)] <light> [<in>] <floor> (off|out)"
+          - "[<turn>] [(<all>|<the>)] <light> (off|out) [<in>] <floor>"
+          - "deactivate [<all>] <floor> <light>"
+          - "deactivate [(<all>|<the>)] <light> [<in>] <floor>"
+        response: "lights_floor"
+        slots:
+          domain: "light"
+
+      # Turn off all lights in the home
+      - sentences:
+          - "<turn> <all> <light> (off|out) [<everywhere>]"
+          - "<turn> [<the>] <light> (off|out) <everywhere>"
+          - "<turn> (off|out) <all> <light> [<everywhere>]"
+          - "<turn> (off|out) [<the>] <light> <everywhere>"
+          - "<turn> (off|out) [<all>] [the] <home> <light> <everywhere>"
+          - "deactivate <all> <light> [<everywhere>]"
+          - "deactivate [<the>] <light> <everywhere>"
+          - "get every <light> (off|out) [<everywhere>]"
+          - "make sure <all> <light> <is> (off|out)"
+        response: "light_all"
+        slots:
+          domain: "light"
+
+      # Turn off lights in the same area as a satellite device
+      - sentences:
+          # Explicit <here> optional all
+          - "<turn> [(<all>|<the>)] <light> (off|out) <here>"
+          - "<turn> [(<all>|<the>)] <light> <here> (off|out)"
+          - "<turn> (off|out) [(<all>|<the>)] <light> <here>"
+          - "deactivate [(<all>|<the>)] <light> <here>"
+          - "[<all>] [<the>] <light> (off|out) <here>"
+
+          # Implicit <here> no all
+          - "<turn> [<the>] <light> (off|out) [<here>]"
+          - "<turn> [<the>] <light> [<here>] (off|out)"
+          - "<turn> (off|out) [<the>] <light> [<here>]"
+          - "deactivate [<the>] <light> [<here>]"
+          - "<light> (off|out) [<here>]"
+        response: "lights_area"
+        slots:
+          domain: "light"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/fa/light_HassTurnOn.yaml
+++ b/sentences/fa/light_HassTurnOn.yaml
@@ -1,8 +1,91 @@
-language: fa
+---
+language: "en"
 intents:
   HassTurnOn:
     data:
-      - sentences: []
+      # Turn on a specific light
+      - sentences:
+          - "<turn> on <area_floor> <name> <light>"
+          - "<turn> on <name> <light> [<in_area_floor>]"
+          - "[<turn>] <area_floor> <name> <light> [to] on"
+          - "[<turn>] <name> <light> [<in_area_floor>] [to] on"
+          - "activate <area_floor> <name> <light>"
+          - "activate <name> <light> [<in_area_floor>]"
+          - "light up <area_floor> <name> <light>"
+          - "light up <name> <light> [<in_area_floor>]"
+        requires_context:
+          domain: "light"
+
+      # Turn on all lights in an area
+      - sentences:
+          - "(light up|illuminate) <area>"
+          - "<area> <light> on"
+          - "<light> on [in] <area>"
+          - "<turn> on [<all>] <area> <light>"
+          - "<turn> on [(<all>|<the>)] <light> <in> <area>"
+          - "[<turn>] [<all>] <area> <light> on"
+          - "[<turn>] [(<all>|<the>)] <light> <in> <area> on"
+          - "[<turn>] [(<all>|<the>)] <light> on <in> <area>"
+          - "activate [<all>] <area> <light>"
+          - "activate [(<all>|<the>)] <light> <in> <area>"
         slots:
-          domain: light
-          name: all
+          domain: "light"
+        response: "lights_area"
+
+      # Turn on all lights on a floor
+      - sentences:
+          - "(light up|illuminate) <floor>"
+          - "<floor> <light> on"
+          - "<light> on [<in>] <floor>"
+          - "<turn> on [<all>] <floor> <light>"
+          - "<turn> on [(<all>|<the>)] <light> [<in>] <floor>"
+          - "[<turn>] [<all>] <floor> <light> on"
+          - "[<turn>] [(<all>|<the>)] <light> [<in>] <floor> on"
+          - "[<turn>] [(<all>|<the>)] <light> on [<in>] <floor>"
+          - "activate [<all>] <floor> <light>"
+          - "activate [(<all>|<the>)] <light> [<in>] <floor>"
+        response: "lights_floor"
+        slots:
+          domain: "light"
+
+      # Turn on all lights in the home
+      - sentences:
+          - "(light up|activate|illuminate) <all> <light> <everywhere>"
+          - "(light up|illuminate) <everywhere> [<everywhere>]"
+          - "<turn> <all> <light> on [<everywhere>]"
+          - "<turn> [<the>] <light> on <everywhere>"
+          - "<turn> on <all> <light> [<everywhere>]"
+          - "<turn> on [<the>] <light> <everywhere>"
+          - "<turn> on [(<all>|<the>)] <home> <light> <everywhere>"
+          - "activate <all> <light> [<everywhere>]"
+          - "activate [<the>] <light> <everywhere>"
+          - "get <all> <light> on [<everywhere>]"
+          - "illuminate <all> areas [<everywhere>]"
+          - make sure <all> <light> <is> on
+        response: "light_all"
+        slots:
+          domain: "light"
+
+      # Turn on lights in the same area as a satellite device
+      - sentences:
+          # Explicit <here> optional all
+          - "<turn> [(<all>|<the>)] <light> on <here>"
+          - "<turn> [(<all>|<the>)] <light> <here> on"
+          - "<turn> on [(<all>|<the>)] <light> <here>"
+          - "activate [(<all>|<the>)] <light> <here>"
+          - "[(<all>|<the>)] <light> on <here>"
+
+          # Implicit <here> no all
+          - "<turn> [<the>] <light> on [<here>]"
+          - "<turn> [<the>] <light> [<here>] on"
+          - "<turn> on [<the>] <light> [<here>]"
+          - "activate [<the>] <light> [<here>]"
+          - "<light> on [<here>]"
+          - "light (it|<here>) up"
+          - "light up [<here>]"
+        response: "lights_area"
+        slots:
+          domain: "light"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/fa/lock_HassGetState.yaml
+++ b/sentences/fa/lock_HassGetState.yaml
@@ -1,0 +1,44 @@
+language: en
+intents:
+  HassGetState:
+    data:
+      - sentences:
+          - "(is|are) <name> ([<currently>];{lock_states:state} [in <area>])"
+        response: one_yesno
+        requires_context:
+          domain: lock
+        slots:
+          domain: lock
+
+      - sentences:
+          - "((is|are) [there]|do I have) any <lockable> ([<currently>];{lock_states:state} [in <area>])"
+          - "((is|are) [there]|do I have) any ([<currently>];{lock_states:state} <lockable> [in <area>])"
+        response: any
+        slots:
+          domain: lock
+
+      - sentences:
+          - "are all <lockable> ([<currently>];{lock_states:state} [in <area>])"
+        response: all
+        slots:
+          domain: lock
+
+      - sentences:
+          - "(which|what) <lockable> (is|are) ([<currently>];{lock_states:state} [in <area>])"
+        response: which
+        slots:
+          domain: lock
+
+      - sentences:
+          - "how many <lockable> (is|are) ([<currently>];{lock_states:state} [in <area>])"
+        response: how_many
+        slots:
+          domain: lock
+
+      - sentences:
+          - "tell me the [current] status of <name> [in <area>] [<currently>]"
+        response: one
+        requires_context:
+          domain: lock
+        slots:
+          domain: lock

--- a/sentences/fa/lock_HassTurnOff.yaml
+++ b/sentences/fa/lock_HassTurnOff.yaml
@@ -1,0 +1,17 @@
+language: en
+intents:
+  HassTurnOff:
+    data:
+      - sentences:
+          - "unlock <name> [in <area>]"
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "unlock [all] <lockable> [in] <area>"
+          - "unlock [all] <area> [<lockable>]"
+        slots:
+          domain: "lock"
+          name: "all"
+        response: lock

--- a/sentences/fa/lock_HassTurnOn.yaml
+++ b/sentences/fa/lock_HassTurnOn.yaml
@@ -1,0 +1,17 @@
+language: en
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "lock <name> [in <area>]"
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "lock [all] <lockable> [in] <area>"
+          - "lock [all] <area> [<lockable>]"
+          - "lock all [of] <lockable>"
+        slots:
+          domain: "lock"
+        response: lock

--- a/sentences/fa/media_player_HassMediaNext.yaml
+++ b/sentences/fa/media_player_HassMediaNext.yaml
@@ -1,0 +1,18 @@
+language: en
+intents:
+  HassMediaNext:
+    data:
+      - sentences:
+          - "next [track|item] [on|for] <name>"
+          - "(skip [(to [the] next [(song|track)]|([the] (song|track)|this [(song|track)]) )];[on] <name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "next [track|item]"
+          - "(skip [(to [the] next [(song|track)]|([the] (song|track)|this [(song|track)]))])"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "next [track|item] [in] <area>"
+          - "(skip [(to [the] next [(song|track)]|([the] (song|track)|this [(song|track)]) )];[in] <area>)"

--- a/sentences/fa/media_player_HassMediaPause.yaml
+++ b/sentences/fa/media_player_HassMediaPause.yaml
@@ -1,0 +1,16 @@
+language: en
+intents:
+  HassMediaPause:
+    data:
+      - sentences:
+          - "(pause;<name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "pause"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "pause [[the|my] (music|[tv] show[s]|media [player[s]])] [in] <area>"
+          - "pause <area> (music|[tv] show[s]|media [player[s]])"

--- a/sentences/fa/media_player_HassMediaPrevious.yaml
+++ b/sentences/fa/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,24 @@
+language: en
+intents:
+  HassMediaPrevious:
+    data:
+      - sentences:
+          - "previous (track|item) [on|for] <name>"
+          - "(go back [to the (previous|last) (song|track)];[on] <name>)"
+          - "replay [the (previous|last) (song|track)] on <name>"
+          - "<name> (play|replay) [the] (previous|last) [(song|track)] [again]"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "previous (track|item)"
+          - "go back [to the (previous|last) (song|track)]"
+          - "replay [the (previous|last) (song|track)] [again]"
+          - "play [the] (previous|last) [(song|track)] [again]"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "previous (track|item) [in] <area>"
+          - "go back [to the (previous|last) (song|track)] [in] <area>"
+          - "(replay [the (previous|last) (song|track)] [again];[in] <area>)"
+          - "(play [the] (previous|last) [(song|track) ][again];[in] <area>)"

--- a/sentences/fa/media_player_HassMediaSearchAndPlay.yaml
+++ b/sentences/fa/media_player_HassMediaSearchAndPlay.yaml
@@ -1,0 +1,29 @@
+language: "en"
+intents:
+  HassMediaSearchAndPlay:
+    data:
+      # current area
+      - sentences:
+          - "play [the] {media_class} {search_query}"
+          - "play [the] {search_query} {media_class}"
+          - "play {search_query}"
+        requires_context:
+          area:
+            slot: true
+
+      # explicit area
+      - sentences:
+          - "play {search_query} in <area>"
+          - "play [the] {media_class} {search_query} in <area>"
+          - "play [the] {search_query} {media_class} in <area>"
+
+      # explicit media player name and area
+      - sentences:
+          - "play {search_query} on <name>"
+          - "play [the] {media_class} {search_query} on <name>"
+          - "play [the] {search_query} {media_class} on <name>"
+          - "play {search_query} on <name> in <area>"
+          - "play [the] {media_class} {search_query} on <name> in <area>"
+          - "play [the] {search_query} {media_class} on <name> in <area>"
+        requires_context:
+          domain: "media_player"

--- a/sentences/fa/media_player_HassMediaUnpause.yaml
+++ b/sentences/fa/media_player_HassMediaUnpause.yaml
@@ -1,0 +1,16 @@
+language: en
+intents:
+  HassMediaUnpause:
+    data:
+      - sentences:
+          - "((unpause|resume);<name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "(unpause|resume)"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "(unpause|resume) [[the|my] (music|[tv] show[s]|media [player[s]])] [in] <area>"
+          - "(unpause|resume) <area> (music|[tv] show[s]|media [player[s]])"

--- a/sentences/fa/media_player_HassSetVolume.yaml
+++ b/sentences/fa/media_player_HassSetVolume.yaml
@@ -1,0 +1,26 @@
+language: en
+intents:
+  HassSetVolume:
+    data:
+      - sentences:
+          - "<numeric_value_set> <name> volume to <volume>"
+          - "turn <name> [volume] (up|down) to <volume>"
+          - "(<numeric_value_set> the volume to <volume>;[on] <name>)"
+          - "(turn (the volume;(up|down)) to <volume>;[on] <name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "<numeric_value_set> volume to <volume>"
+          - "turn volume (up|down) to <volume>"
+          - "<numeric_value_set> the volume to <volume>"
+          - "turn (the volume;(up|down)) to <volume>"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "<numeric_value_set> <area> volume to <volume>"
+          - "turn <area> [volume] (up|down) to <volume>"
+          - "turn [volume] (up|down) to <volume> [in] <area>"
+          - "(<numeric_value_set> the volume to <volume>;[in] <area>)"
+          - "<numeric_value_set> the volume [in] <area> to <volume>"
+          - "(turn (the volume;(up|down)) to <volume>;[in] <area>)"

--- a/sentences/fa/media_player_HassSetVolumeRelative.yaml
+++ b/sentences/fa/media_player_HassSetVolumeRelative.yaml
@@ -1,0 +1,125 @@
+---
+language: en
+intents:
+  HassSetVolumeRelative:
+    data:
+      # Current area
+      - sentences:
+          - "[turn [the]] volume up"
+          - "turn up [the] volume"
+          - "increase [the] volume"
+        slots:
+          volume_step: "up"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "[turn [the]] volume up [by] <volume_step>"
+          - "turn up [the] volume [by] <volume_step>"
+          - "increase [the] volume [by] <volume_step>"
+        expansion_rules:
+          volume_step: "{volume_step_up:volume_step}[%| percent]"
+        requires_context:
+          area:
+            slot: true
+
+      - sentences:
+          - "[turn [the]] volume down"
+          - "turn down [the] volume"
+          - "decrease [the] volume"
+        slots:
+          volume_step: "down"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "[turn [the]] volume down [by] <volume_step>"
+          - "turn down [the] volume [by] <volume_step>"
+          - "decrease [the] volume [by] <volume_step>"
+        expansion_rules:
+          volume_step: "{volume_step_down:volume_step}[%| percent]"
+        requires_context:
+          area:
+            slot: true
+
+      # Media player by name
+      - sentences:
+          - "(<name>;volume up)"
+          - "increase [the] volume [on|for] <name>"
+          - "increase <name> volume"
+          - "turn up <name> volume"
+        slots:
+          volume_step: "up"
+        requires_context:
+          domain: "media_player"
+      - sentences:
+          - "(<name>;volume up) [by] <volume_step>"
+          - "increase [the] volume ([on|for] <name>;[by] <volume_step>)"
+          - "increase <name> volume [by] <volume_step>"
+          - "turn up <name> volume [by] <volume_step>"
+        expansion_rules:
+          volume_step: "{volume_step_up:volume_step}[%| percent]"
+        slots:
+          volume_step: "up"
+        requires_context:
+          domain: "media_player"
+
+      - sentences:
+          - "(<name>;volume down)"
+          - "decrease [the] volume [on|for] <name>"
+          - "decrease <name> volume"
+          - "turn down <name> volume"
+        slots:
+          volume_step: "down"
+        requires_context:
+          domain: "media_player"
+      - sentences:
+          - "(<name>;volume down) [by] <volume_step>"
+          - "decrease [the] volume ([on|for] <name>;[by] <volume_step>)"
+          - "decrease <name> volume [by] <volume_step>"
+          - "turn down <name> volume [by] <volume_step>"
+        expansion_rules:
+          volume_step: "{volume_step_down:volume_step}[%| percent]"
+        slots:
+          volume_step: "down"
+        requires_context:
+          domain: "media_player"
+
+      # Area/floor by name
+      - sentences:
+          - "(<area_floor>;volume up)"
+          - "[turn [the]] volume up (in|on) <area_floor>"
+          - "turn up [the] volume [in|on] <area_floor>"
+          - "turn up <area_floor> volume"
+          - "increase [the] volume [in|on] <area_floor>"
+          - "increase <area_floor> volume"
+        slots:
+          volume_step: "up"
+      - sentences:
+          - "(<area_floor>;volume up) [by] <volume_step>"
+          - "[turn [the]] volume up ((in|on) <area_floor>;[by] <volume_step>)"
+          - "turn up [the] volume ([in|on] <area_floor>;[by] <volume_step>)"
+          - "turn up <area_floor> volume [by] <volume_step>"
+          - "increase [the] volume ([in|on] <area_floor>;[by] <volume_step>)"
+          - "increase <area_floor> volume [by] <volume_step>"
+        expansion_rules:
+          volume_step: "{volume_step_up:volume_step}[%| percent]"
+
+      - sentences:
+          - "(<area_floor>;volume down)"
+          - "[turn [the]] volume down (in|on) <area_floor>"
+          - "turn down [the] volume [in|on] <area_floor>"
+          - "turn down <area_floor> volume"
+          - "decrease [the] volume [in|on] <area_floor>"
+          - "decrease <area_floor> volume"
+        slots:
+          volume_step: "down"
+      - sentences:
+          - "(<area_floor>;volume down) [by] <volume_step>"
+          - "[turn [the]] volume down ((in|on) <area_floor>;[by] <volume_step>)"
+          - "turn down [the] volume ([in|on] <area_floor>;[by] <volume_step>)"
+          - "turn down <area_floor> volume [by] <volume_step>"
+          - "decrease [the] volume ([in|on] <area_floor>;[by] <volume_step>)"
+          - "decrease <area_floor> volume [by] <volume_step>"
+        expansion_rules:
+          volume_step: "{volume_step_down:volume_step}[%| percent]"

--- a/sentences/fa/person_HassGetState.yaml
+++ b/sentences/fa/person_HassGetState.yaml
@@ -1,0 +1,44 @@
+language: en
+intents:
+  HassGetState:
+    data:
+      # https://www.home-assistant.io/integrations/person/
+      - sentences:
+          - "<where_is> <name>"
+        response: where
+        requires_context:
+          domain: person
+        slots:
+          domain: person
+
+      - sentences:
+          - "is <name> [<in>] [the] {zone:state}"
+        response: one_yesno
+        requires_context:
+          domain: person
+        slots:
+          domain: person
+
+      - sentences:
+          - "is anyone [<in>] [the] {zone:state}"
+        response: any
+        slots:
+          domain: person
+
+      - sentences:
+          - "is everyone [<in>] [the] {zone:state}"
+        response: all
+        slots:
+          domain: person
+
+      - sentences:
+          - "who is [<in>] [the] {zone:state}"
+        response: which
+        slots:
+          domain: person
+
+      - sentences:
+          - "how many people are [<in>] [the] {zone:state}"
+        response: how_many
+        slots:
+          domain: person

--- a/sentences/fa/scene_HassTurnOn.yaml
+++ b/sentences/fa/scene_HassTurnOn.yaml
@@ -1,0 +1,27 @@
+language: en
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "[activate] <name> [scene]"
+          - "<name> on"
+          - "<turn> (<name> [scene];on)"
+          - "(change|transition) to (<name> [scene]|scene <name>)"
+        requires_context:
+          domain: scene
+        slots:
+          domain: scene
+        response: scene
+      - sentences:
+          - "[activate] <area> <name> [scene]"
+          - "<area> <name> on"
+          - "<turn> (<area> <name> [scene];on)"
+          - "[activate] <name> [scene] <in> <area>"
+          - "<turn> (<name> [scene] <in> <area>;on)"
+          - "(change|transition) ([to] <area> <name>|<area> to <name>) [scene]"
+          - "(change|transition) to <name> [scene] <in> <area>"
+        requires_context:
+          domain: scene
+        slots:
+          domain: scene
+        response: scene

--- a/sentences/fa/script_HassTurnOn.yaml
+++ b/sentences/fa/script_HassTurnOn.yaml
@@ -1,0 +1,11 @@
+language: en
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "[activate|run|start|<turn>] <name> [script] [on]"
+        requires_context:
+          domain: script
+        slots:
+          domain: script
+        response: script

--- a/sentences/fa/sensor_HassGetState.yaml
+++ b/sentences/fa/sensor_HassGetState.yaml
@@ -1,0 +1,621 @@
+language: en
+intents:
+  HassGetState:
+    data:
+      # https://www.home-assistant.io/integrations/sensor/
+      # Apparent power
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: apparent_power
+        slots:
+          domain: sensor
+          device_class: apparent_power
+        expansion_rules:
+          class: "apparent power"
+
+      # AQI
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: aqi
+        slots:
+          domain: sensor
+          device_class: aqi
+        expansion_rules:
+          class: "(AQI|air quality [index])"
+
+      # Atmospheric pressure
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: atmospheric_pressure
+        slots:
+          domain: sensor
+          device_class: atmospheric_pressure
+        expansion_rules:
+          class: "(atmospheric|air) pressure"
+
+      # Battery
+      - sentences:
+          - "<what_is_the_class_of_name>"
+          - "how much battery (does <name> have [left]|has <name> got [left]|is left in <name>)"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: battery
+        slots:
+          domain: sensor
+          device_class: battery
+        expansion_rules:
+          class: "[remaining] battery [level]"
+
+      # CO2
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: carbon_dioxide
+        slots:
+          domain: sensor
+          device_class: carbon_dioxide
+        expansion_rules:
+          class: "(carbon dioxide|CO2) (level|concentration)"
+
+      # CO
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: carbon_monoxide
+        slots:
+          domain: sensor
+          device_class: carbon_monoxide
+        expansion_rules:
+          class: "(carbon monoxide|CO) (level|concentration)"
+
+      # Current
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: current
+        slots:
+          domain: sensor
+          device_class: current
+        expansion_rules:
+          class: "[amount of] [electric[al]] current"
+
+      # Data rate
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: data_rate
+        slots:
+          domain: sensor
+          device_class: data_rate
+        expansion_rules:
+          class: "[(download|upload|data)] (rate|speed)"
+
+      # Data size
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: data_size
+        slots:
+          domain: sensor
+          device_class: data_size
+        expansion_rules:
+          class: "([data] size|(amount|size) of [the] data)"
+
+      # Date
+      - sentences:
+          - "<what_is_the_class_of_name>"
+          - "when ((is|was) <name>|will <name> be|(will|did) <name> happen)"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: date
+        slots:
+          domain: sensor
+          device_class: date
+        expansion_rules:
+          class: "[calendar[istic]] date"
+
+      # Distance
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: distance
+        slots:
+          domain: sensor
+          device_class: distance
+        expansion_rules:
+          class: "distance"
+
+      # Duration
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: duration
+        slots:
+          domain: sensor
+          device_class: duration
+        expansion_rules:
+          class: "duration"
+
+      # Energy
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: energy
+        slots:
+          domain: sensor
+          device_class: energy
+        expansion_rules:
+          class: "[amount of] energy"
+
+      # Energy storage
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: energy_storage
+        slots:
+          domain: sensor
+          device_class: energy_storage
+        expansion_rules:
+          class: "[[total] amount of] [stored] energy"
+
+      # Skipping enum
+
+      # Frequency
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: frequency
+        slots:
+          domain: sensor
+          device_class: frequency
+        expansion_rules:
+          class: "frequency"
+
+      # Gas
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: gas
+        slots:
+          domain: sensor
+          device_class: gas
+        expansion_rules:
+          class: "[amount of] gas [volume]"
+
+      # Humidity
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: humidity
+        slots:
+          domain: sensor
+          device_class: humidity
+        expansion_rules:
+          class: "[(air|atmospheric)] [relative] humidity"
+
+      # Illuminance
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: illuminance
+        slots:
+          domain: sensor
+          device_class: illuminance
+        expansion_rules:
+          class: "([amount of] illuminance|(light|brightness) level)"
+
+      # Irradiance
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: irradiance
+        slots:
+          domain: sensor
+          device_class: irradiance
+        expansion_rules:
+          class: "([amount of] irradiance|[ir]radiation level)"
+
+      # Moisture
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: moisture
+        slots:
+          domain: sensor
+          device_class: moisture
+        expansion_rules:
+          class: "([relative] moisture|(percentage|ratio) of water)"
+
+      # Monetary
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: monetary
+        slots:
+          domain: sensor
+          device_class: monetary
+        expansion_rules:
+          class: "[amount of] (money|cash|cost)"
+
+      # Nitrogen dioxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: nitrogen_dioxide
+        slots:
+          domain: sensor
+          device_class: nitrogen_dioxide
+        expansion_rules:
+          class: "(nitrogen dioxide|NO2) (level|concentration)"
+
+      # Nitrogen monoxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: nitrogen_monoxide
+        slots:
+          domain: sensor
+          device_class: nitrogen_monoxide
+        expansion_rules:
+          class: "(nitrogen monoxide|NO) (level|concentration)"
+
+      # Nitrous oxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: nitrous_oxide
+        slots:
+          domain: sensor
+          device_class: nitrous_oxide
+        expansion_rules:
+          class: "(nitrous oxide|N2O) (level|concentration)"
+
+      # Ozone
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: ozone
+        slots:
+          domain: sensor
+          device_class: ozone
+        expansion_rules:
+          class: "(ozone|O3) level"
+
+      # PM1
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pm1
+        slots:
+          domain: sensor
+          device_class: pm1
+        expansion_rules:
+          class: "((level|concentration) [of] PM1 [particles]|PM1 [particles] [level|concentration])"
+
+      # PM2.5
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pm25
+        slots:
+          domain: sensor
+          device_class: pm25
+        expansion_rules:
+          class: "((level|concentration) [of] PM2.5 [particles]|PM2.5 [particles] [level|concentration])"
+
+      # PM10
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pm10
+        slots:
+          domain: sensor
+          device_class: pm10
+        expansion_rules:
+          class: "((level|concentration) [of] PM10 [particles]|PM10 [particles] [level|concentration])"
+
+      # Power factor
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: power_factor
+        slots:
+          domain: sensor
+          device_class: power_factor
+        expansion_rules:
+          class: "power factor"
+
+      # Power
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: power
+        slots:
+          domain: sensor
+          device_class: power
+        expansion_rules:
+          class: "power"
+
+      # Precipitation
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: precipitation
+        slots:
+          domain: sensor
+          device_class: precipitation
+        expansion_rules:
+          class: "[accumulated] (precipitation|(rain|snow)[fall]) [level|quantity]"
+
+      # Precipitation intensity
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: precipitation_intensity
+        slots:
+          domain: sensor
+          device_class: precipitation_intensity
+        expansion_rules:
+          class: "(precipitation|(rain|snow)[fall]) (intensity|rate)"
+
+      # Pressure
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pressure
+        slots:
+          domain: sensor
+          device_class: pressure
+        expansion_rules:
+          class: "pressure"
+
+      # Reactive power
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: reactive_power
+        slots:
+          domain: sensor
+          device_class: reactive_power
+        expansion_rules:
+          class: "reactive power"
+
+      # Signal strength
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: signal_strength
+        slots:
+          domain: sensor
+          device_class: signal_strength
+        expansion_rules:
+          class: "signal strength"
+
+      # Sound pressure
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: sound_pressure
+        slots:
+          domain: sensor
+          device_class: sound_pressure
+        expansion_rules:
+          class: "(sound|acoustic) pressure"
+
+      # Speed
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: speed
+        slots:
+          domain: sensor
+          device_class: speed
+        expansion_rules:
+          class: "(speed|velocity)"
+
+      # Sulphur dioxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: sulphur_dioxide
+        slots:
+          domain: sensor
+          device_class: sulphur_dioxide
+        expansion_rules:
+          class: "(sulphur dioxide|SO2) (level|concentration)"
+
+      # Temperature
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: temperature
+        slots:
+          domain: sensor
+          device_class: temperature
+        expansion_rules:
+          class: "temperature"
+
+      # Skipping Timestamp
+
+      # Volatile organic compounds
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volatile_organic_compounds
+        slots:
+          domain: sensor
+          device_class: volatile_organic_compounds
+        expansion_rules:
+          class: "[concentration of] (VOC[s]|[volatile] organic compound[s])"
+
+      # Volatile organic compounds
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volatile_organic_compounds_parts
+        slots:
+          domain: sensor
+          device_class: volatile_organic_compounds_parts
+        expansion_rules:
+          class: "[(concentration|ratio) of] (VOC[s]|[volatile] organic compound[s])"
+
+      # Voltage
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: voltage
+        slots:
+          domain: sensor
+          device_class: voltage
+        expansion_rules:
+          class: "voltage [drop]"
+
+      # Volume
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volume
+        slots:
+          domain: sensor
+          device_class: volume
+        expansion_rules:
+          class: "volume"
+
+      # Volume storage
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volume_storage
+        slots:
+          domain: sensor
+          device_class: volume_storage
+        expansion_rules:
+          class: "[total] [stored] volume"
+
+      # Water
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: water
+        slots:
+          domain: sensor
+          device_class: water
+        expansion_rules:
+          class: "[total] ([amount of] [consumed] water|water consumption)"
+
+      # Weight
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: weight
+        slots:
+          domain: sensor
+          device_class: weight
+        expansion_rules:
+          class: "(weight|mass)"
+
+      # Wind speed
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: wind_speed
+        slots:
+          domain: sensor
+          device_class: wind_speed
+        expansion_rules:
+          class: "[wind] (speed|velocity)"

--- a/sentences/fa/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/fa/shopping_list_HassShoppingListAddItem.yaml
@@ -1,0 +1,11 @@
+language: "en"
+intents:
+  HassShoppingListAddItem:
+    data:
+      - sentences:
+          - add <item> to <my_list>
+          - put <item> (on|in) <my_list>
+        response: item_added
+        expansion_rules:
+          my_list: "[my|the] [shopping] list"
+          item: "{shopping_list_item:item}"

--- a/sentences/fa/shopping_list_HassShoppingListCompleteItem.yaml
+++ b/sentences/fa/shopping_list_HassShoppingListCompleteItem.yaml
@@ -1,0 +1,11 @@
+language: "en"
+intents:
+  HassShoppingListCompleteItem:
+    data:
+      - sentences:
+          - (check|complete|delete|remove) (off;<item>) (from|on|in) <my_list>
+          - (check|complete|delete|remove) <item> (off|from|on|in) <my_list>
+        response: item_completed
+        expansion_rules:
+          my_list: "[my|the] [shopping] list"
+          item: "{shopping_list_item:item}"

--- a/sentences/fa/todo_HassListAddItem.yaml
+++ b/sentences/fa/todo_HassListAddItem.yaml
@@ -1,0 +1,13 @@
+language: "en"
+intents:
+  HassListAddItem:
+    data:
+      - sentences:
+          - add <item> to <my_list>
+          - put <item> (on|in) <my_list>
+        response: item_added
+        requires_context:
+          domain: todo
+        expansion_rules:
+          my_list: "[my|the] {name} [list]"
+          item: "{todo_list_item:item}"

--- a/sentences/fa/todo_HassListCompleteItem.yaml
+++ b/sentences/fa/todo_HassListCompleteItem.yaml
@@ -1,0 +1,13 @@
+language: "en"
+intents:
+  HassListCompleteItem:
+    data:
+      - sentences:
+          - (check|complete|delete|remove) (off;<item>) (from|on|in) <my_list>
+          - (check|complete|delete|remove) <item> (off|from|on|in) <my_list>
+        response: item_completed
+        requires_context:
+          domain: todo
+        expansion_rules:
+          my_list: "[my|the] {name} [list]"
+          item: "{todo_list_item:item}"

--- a/sentences/fa/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/fa/vacuum_HassVacuumReturnToBase.yaml
@@ -1,0 +1,8 @@
+language: en
+intents:
+  HassVacuumReturnToBase:
+    data:
+      - sentences:
+          - "return <name> [to base]"
+        requires_context:
+          domain: vacuum

--- a/sentences/fa/vacuum_HassVacuumStart.yaml
+++ b/sentences/fa/vacuum_HassVacuumStart.yaml
@@ -1,0 +1,10 @@
+language: en
+intents:
+  HassVacuumStart:
+    data:
+      - sentences:
+          - "start <name>"
+        requires_context:
+          domain: vacuum
+      - sentences:
+          - <clean> <floor>

--- a/sentences/fa/valve_HassSetPosition.yaml
+++ b/sentences/fa/valve_HassSetPosition.yaml
@@ -1,0 +1,10 @@
+language: en
+intents:
+  HassSetPosition:
+    data:
+      - sentences:
+          - "(<numeric_value_set>|<open>|<close>) <name> [position] to <position>"
+        requires_context:
+          domain: valve
+        slots:
+          domain: valve

--- a/sentences/fa/valve_HassTurnOff.yaml
+++ b/sentences/fa/valve_HassTurnOff.yaml
@@ -1,0 +1,11 @@
+language: en
+intents:
+  HassTurnOff:
+    data:
+      - sentences:
+          - "<close> <name>"
+        requires_context:
+          domain: valve
+        slots:
+          domain: valve
+        response: valve

--- a/sentences/fa/valve_HassTurnOn.yaml
+++ b/sentences/fa/valve_HassTurnOn.yaml
@@ -1,0 +1,11 @@
+language: en
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "<open> <name>"
+        requires_context:
+          domain: valve
+        slots:
+          domain: valve
+        response: valve

--- a/sentences/fa/weather_HassGetWeather.yaml
+++ b/sentences/fa/weather_HassGetWeather.yaml
@@ -1,0 +1,12 @@
+language: en
+intents:
+  HassGetWeather:
+    data:
+      - sentences:
+          - "<what_is> [the] weather [like]"
+      - sentences:
+          - "<what_is> [the] weather [like] (for|in|at) <name>"
+          - "<what_is> [the] weather (for|in|at) <name> [like]"
+          - "<what_is> [the] <name> weather [like]"
+        requires_context:
+          domain: weather


### PR DESCRIPTION
## Summary
- Duplicate English sentence templates into the Farsi `sentences/fa` directory

## Testing
- `python3 -m script.intentfest validate --language fa` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests --language fa` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68b0550f498c832d9461334dec2420bd